### PR TITLE
Fix StartupWMClass in desktop template

### DIFF
--- a/templates/firefox-opt.desktop.j2
+++ b/templates/firefox-opt.desktop.j2
@@ -3,7 +3,7 @@
 Name=Firefox OPT
 Comment=Browse the World Wide Web
 GenericName=Web Browser
-X-GNOME-FullName=Firefox OPT Web Browser
+X-GNOME-FullName=Firefox Web Browser in OPT
 Exec={{ oom_cmd }} %u
 Terminal=false
 X-MultipleArgs=false

--- a/templates/firefox-opt.desktop.j2
+++ b/templates/firefox-opt.desktop.j2
@@ -11,7 +11,7 @@ Type=Application
 Icon={{ mozilla_firefox_dest }}/firefox/browser/chrome/icons/default/default128.png
 Categories=Network;WebBrowser;
 MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/vnd.mozilla.xul+xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;
-StartupWMClass=Firefox
+StartupWMClass=firefox
 StartupNotify=true
 Actions=new-window;new-private-window;
 


### PR DESCRIPTION
The previous value in StartupWMClass didn't match the actual value in WM_CLASS as reported by xprop.